### PR TITLE
Fix score manager reset

### DIFF
--- a/manager/score_manager.gd
+++ b/manager/score_manager.gd
@@ -31,7 +31,8 @@ func on_level_up():
 func reset():
         ScoreManager.score = 0
         ScoreManager.level_up_score_needed = 500
-        ScoreManager.score_needed_growth = 250
+        ScoreManager.score_needed_base = 500
+        ScoreManager.score_needed_growth = 750
 
 func load_high_score():
         if FileAccess.file_exists(SAVE_PATH):


### PR DESCRIPTION
## Summary
- restore base and growth XP thresholds in `ScoreManager.reset`

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d19e2bb083228a4c5547e5004c4b