### PR TITLE
Fix reset on PlayerManager and WeaponManager

### DIFF
--- a/manager/player_manager.gd
+++ b/manager/player_manager.gd
@@ -14,8 +14,12 @@ var shoot_wait_time: float = 0.25
 
 
 func reset():
-	lives = 3
-	cur_speed = MIN_SPEED
+        lives = 3
+        cur_speed = MIN_SPEED
+        max_speed = INIT_MAX_SPEED
+        speed_level = 1
+        weapon_speed_level = 1
+        shoot_wait_time = 0.25
 
 
 func increase_max_speed(i: int):

--- a/manager/weapon_manager.gd
+++ b/manager/weapon_manager.gd
@@ -5,7 +5,8 @@ var weapon_power = level * 5.0
 
 
 func reset():
-	level = 1
+        level = 1
+        weapon_power = level * 5.0
 	
 	
 func increase_weapon_power(i: int):


### PR DESCRIPTION
## Summary
- reset player speed and shooting values properly
- recompute weapon power on weapon reset

## Testing
- `godot --headless --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d19f1ad88322bf4fb2db96805135