### PR TITLE
Refactor level scripts with shared base

### DIFF
--- a/scenes/levels/base_level.gd
+++ b/scenes/levels/base_level.gd
@@ -1,0 +1,115 @@
+class_name BaseLevel
+extends Node
+
+@onready var enemy_spawn_timer = $EnemySpawnTimer
+@onready var enemy_spawners = [
+$HBEnemySpawner/EnemySpawner1,
+$HBEnemySpawner/EnemySpawner2,
+$HBEnemySpawner/EnemySpawner3,
+$HBEnemySpawner/EnemySpawner4,
+$HBEnemySpawner/EnemySpawner5,
+$HBEnemySpawner/EnemySpawner6,
+$HBEnemySpawner/EnemySpawner7,
+$HBEnemySpawner/EnemySpawner8
+]
+
+var enemy_scenes: Array[PackedScene] = []
+var sublevel_limits: Array[int] = []
+var sublevel_configs: Array = []
+var enemy_probabilities: Array = []
+var current_sublevel := 0
+
+func _ready():
+clean_scene()
+SignalManager.final_blitz_warning.connect(on_final_blitz_warning)
+if sublevel_configs.size() > 0:
+    apply_sublevel_config(0)
+
+func _process(delta):
+verify_progress()
+
+func verify_progress():
+if sublevel_limits.size() >= 3:
+    if GameManager.enemy_killed >= sublevel_limits[2] and current_sublevel == 3:
+        GameManager.is_final_blitz = true
+        if get_tree().get_nodes_in_group("enemy").size() <= 0:
+            SignalManager.level_finished.emit()
+            if has_node("AudioStreamPlayer"):
+                $AudioStreamPlayer.stop()
+    if GameManager.enemy_killed >= sublevel_limits[2] and current_sublevel == 2:
+        enemy_spawn_timer.stop()
+        var enemies = get_tree().get_nodes_in_group("enemy")
+        if enemies.size() > 0:
+            for enemy in enemies:
+                if enemy.global_position.y <= -25:
+                    SignalManager.final_blitz_warning.emit()
+                    if has_node("AudioStreamPlayer"):
+                        $AudioStreamPlayer.play()
+                    current_sublevel = 3
+                    break
+        current_sublevel = 3
+if GameManager.enemy_killed >= sublevel_limits[1] and current_sublevel == 1:
+    apply_sublevel_config(2)
+if GameManager.enemy_killed >= sublevel_limits[0] and current_sublevel == 0:
+    apply_sublevel_config(1)
+
+func apply_sublevel_config(index:int) -> void:
+if index >= sublevel_configs.size():
+    return
+var cfg = sublevel_configs[index]
+if cfg.has("timer_min"):
+    GameManager.enemy_spawn_timer_min = cfg["timer_min"]
+if cfg.has("timer_max"):
+    GameManager.enemy_spawn_timer_max = cfg["timer_max"]
+if cfg.has("probabilities"):
+    enemy_probabilities = cfg["probabilities"]
+current_sublevel = index
+
+func _on_enemy_spawn_timer_timeout():
+if !GameManager.is_final_blitz:
+    spawn_enemy()
+
+func spawn_enemy():
+if enemy_scenes.is_empty() or enemy_probabilities.is_empty():
+    return
+var index = weighted_random(enemy_probabilities)
+var enemy = enemy_scenes[index].instantiate() as Node2D
+get_tree().root.add_child(enemy)
+var spawner_index = randi_range(0, enemy_spawners.size() - 1)
+enemy.global_position = enemy_spawners[spawner_index].global_position
+enemy_spawn_timer.wait_time = randf_range(GameManager.enemy_spawn_timer_min, GameManager.enemy_spawn_timer_max)
+enemy_spawn_timer.start()
+
+func weighted_random(weights:Array) -> int:
+var total = 0
+for w in weights:
+    total += w
+var rnd = randf_range(0.0, total)
+var cumulative = 0.0
+for i in range(weights.size()):
+    cumulative += weights[i]
+    if rnd < cumulative:
+        return i
+return weights.size() - 1
+
+func clean_scene():
+EnemyManager.speed = EnemyManager.MIN_SPEED
+var enemies = get_tree().root.get_children()
+for e in enemies:
+    if e.is_in_group("enemy"):
+        e.queue_free()
+
+func on_final_blitz_warning():
+var enemies_missed = $HBEnemies.get_children()
+if enemies_missed.is_empty():
+    SignalManager.start_final_blitz.emit()
+else:
+    for enemy in enemies_missed:
+        enemy.play("flash")
+    $FinalBlitzWarningTimer.start()
+
+func _on_final_blitz_warning_timer_timeout():
+var enemies_missed = $HBEnemies.get_children()
+for enemy in enemies_missed:
+    enemy.queue_free()
+SignalManager.start_final_blitz.emit()

--- a/scenes/levels/level1.gd
+++ b/scenes/levels/level1.gd
@@ -1,122 +1,20 @@
-extends Node
-@onready var enemy_spawn_timer = $EnemySpawnTimer
-@onready var enemy_spawner_1 = $HBEnemySpawner/EnemySpawner1
-@onready var enemy_spawner_2 = $HBEnemySpawner/EnemySpawner2
-@onready var enemy_spawner_3 = $HBEnemySpawner/EnemySpawner3
-@onready var enemy_spawner_4 = $HBEnemySpawner/EnemySpawner4
-@onready var enemy_spawner_5 = $HBEnemySpawner/EnemySpawner5
-@onready var enemy_spawner_6 = $HBEnemySpawner/EnemySpawner6
-@onready var enemy_spawner_7 = $HBEnemySpawner/EnemySpawner7
-@onready var enemy_spawner_8 = $HBEnemySpawner/EnemySpawner8
+extends BaseLevel
 
 var enemy1 = preload("res://scenes/enemies/enemy1red.tscn")
 var enemy2 = preload("res://scenes/enemies/enemy1green.tscn")
 @onready var FinalBlitzMusic = $AudioStreamPlayer
 
-var enemy_2_probability = -5
-
 var level_1_limit = 5
 var level_2_limit = 10
 var level_3_limit = 15
-var current_sublevel = 0
-var is_flawless_victory = false
-
 
 func _ready():
-	clean_scene()
-	SignalManager.final_blitz_warning.connect(on_final_blitz_warning)
+    enemy_scenes = [enemy1, enemy2]
+    sublevel_limits = [level_1_limit, level_2_limit, level_3_limit]
+    sublevel_configs = [
+        {"probabilities": [100, 0]},
+        {"timer_min": 1.5, "timer_max": 3.0, "probabilities": [70, 30]},
+        {"timer_min": 1.0, "timer_max": 2.0, "probabilities": [45, 55]}
+    ]
+    super._ready()
 
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
-	verify_progress()
-
-
-func verify_progress():	
-	if level_3_limit <= GameManager.enemy_killed and current_sublevel == 3:
-		GameManager.is_final_blitz = true
-		if get_tree().get_nodes_in_group("enemy").size() <= 0:
-			SignalManager.level_finished.emit()	
-			FinalBlitzMusic.stop()
-	if level_3_limit <= GameManager.enemy_killed and current_sublevel == 2:
-		enemy_spawn_timer.stop()	
-		var enemies = get_tree().get_nodes_in_group("enemy")
-		if enemies.size() > 0:
-			for enemy in enemies:
-				if enemy.global_position.y <= -25:				
-					SignalManager.final_blitz_warning.emit()
-					FinalBlitzMusic.play()
-					current_sublevel = 3		
-					break
-		current_sublevel = 3		
-	if level_2_limit <= GameManager.enemy_killed and current_sublevel == 1:
-		GameManager.enemy_spawn_timer_min = 1.0
-		GameManager.enemy_spawn_timer_max = 2.0
-		current_sublevel = 2
-		enemy_2_probability = 55		
-	if level_1_limit <= GameManager.enemy_killed and current_sublevel == 0:
-		GameManager.enemy_spawn_timer_min = 1.5
-		GameManager.enemy_spawn_timer_max = 3.0
-		current_sublevel = 1
-		enemy_2_probability = 30
-		
-
-func _on_enemy_spawn_timer_timeout():
-	if !GameManager.is_final_blitz:
-		spawn_enemy()
-	
-	
-func spawn_enemy():	
-	var e
-	var rnd = randi_range(0,100)
-	if enemy_2_probability >=rnd:
-		e = enemy2.instantiate() as Node2D
-	else:
-		e = enemy1.instantiate() as Node2D
-	
-	get_tree().root.add_child(e)
-	var i = randi_range(1, 8)
-	match i:
-		1: 
-			e.global_position = enemy_spawner_1.global_position
-		2: 
-			e.global_position = enemy_spawner_2.global_position
-		3: 
-			e.global_position = enemy_spawner_3.global_position
-		4: 
-			e.global_position = enemy_spawner_4.global_position
-		5: 
-			e.global_position = enemy_spawner_5.global_position
-		6: 
-			e.global_position = enemy_spawner_6.global_position
-		7: 
-			e.global_position = enemy_spawner_7.global_position
-		8: 
-			e.global_position = enemy_spawner_8.global_position
-			
-	enemy_spawn_timer.wait_time = randf_range(GameManager.enemy_spawn_timer_min, GameManager.enemy_spawn_timer_max)
-	enemy_spawn_timer.start()
-	
-
-func clean_scene():
-	var enemies = get_tree().root.get_children()
-	for e in enemies:
-		if e.is_in_group("enemy"):
-			e.queue_free()
-			
-			
-func on_final_blitz_warning():
-	var enemies_missed = $HBEnemies.get_children()
-	if enemies_missed.is_empty():
-		SignalManager.start_final_blitz.emit()
-	else:
-		for enemy in enemies_missed:
-			enemy.play("flash")
-		$FinalBlitzWarningTimer.start()
-		
-
-func _on_final_blitz_warning_timer_timeout():
-	var enemies_missed = $HBEnemies.get_children()
-	for enemy in enemies_missed:
-		enemy.queue_free()
-	SignalManager.start_final_blitz.emit()

--- a/scenes/levels/level2.gd
+++ b/scenes/levels/level2.gd
@@ -1,138 +1,29 @@
-extends Node
-@onready var enemy_spawn_timer = $EnemySpawnTimer
-@onready var enemy_spawner_1 = $HBEnemySpawner/EnemySpawner1
-@onready var enemy_spawner_2 = $HBEnemySpawner/EnemySpawner2
-@onready var enemy_spawner_3 = $HBEnemySpawner/EnemySpawner3
-@onready var enemy_spawner_4 = $HBEnemySpawner/EnemySpawner4
-@onready var enemy_spawner_5 = $HBEnemySpawner/EnemySpawner5
-@onready var enemy_spawner_6 = $HBEnemySpawner/EnemySpawner6
-@onready var enemy_spawner_7 = $HBEnemySpawner/EnemySpawner7
-@onready var enemy_spawner_8 = $HBEnemySpawner/EnemySpawner8
+extends BaseLevel
 
 var enemy1 = preload("res://scenes/enemies/enemy1red.tscn")
 var enemy2 = preload("res://scenes/enemies/enemy1green.tscn")
 var enemy3 = preload("res://scenes/enemies/enemy2red.tscn")
 @onready var final_blitz_music = $FinalBlitzMusic
 
-var enemy_2_probability = 35
-var enemy_3_probability = -5
-
-var level_1_limit = 5#15
-var level_2_limit = 10#25
-var level_3_limit = 15#45
-var current_sublevel = 0
-var is_flawless_victory = false
-
+var level_1_limit = 5
+var level_2_limit = 10
+var level_3_limit = 15
 
 func _ready():
-	clean_scene()
-	SignalManager.final_blitz_warning.connect(on_final_blitz_warning)
-	update_ui()
+    enemy_scenes = [enemy1, enemy2, enemy3]
+    sublevel_limits = [level_1_limit, level_2_limit, level_3_limit]
+    sublevel_configs = [
+        {"probabilities": [65, 35, 0]},
+        {"timer_min": 1.5, "timer_max": 3.0, "probabilities": [70, 15, 15]},
+        {"timer_min": 1.0, "timer_max": 2.0, "probabilities": [40, 30, 30]}
+    ]
+    update_ui()
+    super._ready()
 
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
-	verify_progress()
-	
-	
-func verify_progress():
-	if level_3_limit <= GameManager.enemy_killed and current_sublevel == 3:
-		GameManager.is_final_blitz = true
-		if get_tree().get_nodes_in_group("enemy").size() <= 0:
-			SignalManager.level_finished.emit()		
-			final_blitz_music.stop()
-	if level_3_limit <= GameManager.enemy_killed and current_sublevel == 2:
-		enemy_spawn_timer.stop()	
-		var enemies = get_tree().get_nodes_in_group("enemy")
-		if enemies.size() > 0:
-			for enemy in enemies:
-				if enemy.global_position.y <= -25:				
-					SignalManager.final_blitz_warning.emit()
-					final_blitz_music.play()
-					current_sublevel = 3		
-					break
-		current_sublevel = 3					
-	if level_2_limit <= GameManager.enemy_killed and current_sublevel == 1:
-		GameManager.enemy_spawn_timer_min = 1.0
-		GameManager.enemy_spawn_timer_max = 2.0
-		current_sublevel = 2
-		enemy_2_probability = 60
-		enemy_3_probability = 30		
-	if level_1_limit <= GameManager.enemy_killed and current_sublevel == 0:
-		GameManager.enemy_spawn_timer_min = 1.5
-		GameManager.enemy_spawn_timer_max = 3.0
-		current_sublevel = 1
-		enemy_2_probability = 30
-		enemy_3_probability = 15
-		
-
-func _on_enemy_spawn_timer_timeout():
-	if !GameManager.is_final_blitz:
-		spawn_enemy()
-	
-	
-func spawn_enemy():	
-	var e
-	var rnd = randi_range(0,100)
-	if enemy_3_probability >=rnd:
-		e = enemy3.instantiate() as Node2D
-	elif enemy_2_probability >=rnd:
-		e = enemy2.instantiate() as Node2D
-	else:
-		e = enemy1.instantiate() as Node2D
-	
-	get_tree().root.add_child(e)
-	var i = randi_range(1, 8)
-	match i:
-		1: 
-			e.global_position = enemy_spawner_1.global_position
-		2: 
-			e.global_position = enemy_spawner_2.global_position
-		3: 
-			e.global_position = enemy_spawner_3.global_position
-		4: 
-			e.global_position = enemy_spawner_4.global_position
-		5: 
-			e.global_position = enemy_spawner_5.global_position
-		6: 
-			e.global_position = enemy_spawner_6.global_position
-		7: 
-			e.global_position = enemy_spawner_7.global_position
-		8: 
-			e.global_position = enemy_spawner_8.global_position
-			
-	enemy_spawn_timer.wait_time = randf_range(GameManager.enemy_spawn_timer_min, GameManager.enemy_spawn_timer_max)
-	
-
-func clean_scene():
-	EnemyManager.speed = EnemyManager.MIN_SPEED
-	var enemies = get_tree().root.get_children()
-	for e in enemies:
-		if e.is_in_group("enemy"):
-			e.queue_free()
-			
-			
 func update_ui():
-	SignalManager.speed_update.emit(false)
-	SignalManager.score_updated.emit(0)
-	SignalManager.weapon_speed_update.emit(false)
-	SignalManager.weapon_update.emit(false)
-	SignalManager.combo_update.emit()
-			
-			
-func on_final_blitz_warning():
-	var enemies_missed = $HBEnemies.get_children()
-	if enemies_missed.is_empty():
-		SignalManager.start_final_blitz.emit()
-	else:
-		for enemy in enemies_missed:
-			enemy.play("flash")
-		$FinalBlitzWarningTimer.start()
-		
+    SignalManager.speed_update.emit(false)
+    SignalManager.score_updated.emit(0)
+    SignalManager.weapon_speed_update.emit(false)
+    SignalManager.weapon_update.emit(false)
+    SignalManager.combo_update.emit()
 
-
-func _on_final_blitz_warning_timer_timeout():
-        var enemies_missed = $HBEnemies.get_children()
-        for enemy in enemies_missed:
-                enemy.queue_free()
-        SignalManager.start_final_blitz.emit()

--- a/scenes/levels/level3.gd
+++ b/scenes/levels/level3.gd
@@ -1,150 +1,60 @@
-extends Node
-@onready var enemy_spawn_timer = $EnemySpawnTimer
-@onready var enemy_spawner_1 = $HBEnemySpawner/EnemySpawner1
-@onready var enemy_spawner_2 = $HBEnemySpawner/EnemySpawner2
-@onready var enemy_spawner_3 = $HBEnemySpawner/EnemySpawner3
-@onready var enemy_spawner_4 = $HBEnemySpawner/EnemySpawner4
-@onready var enemy_spawner_5 = $HBEnemySpawner/EnemySpawner5
-@onready var enemy_spawner_6 = $HBEnemySpawner/EnemySpawner6
-@onready var enemy_spawner_7 = $HBEnemySpawner/EnemySpawner7
-@onready var enemy_spawner_8 = $HBEnemySpawner/EnemySpawner8
+extends BaseLevel
 
-
+var enemy2red = preload("res://scenes/enemies/enemy2red.tscn")
 var enemy1green = preload("res://scenes/enemies/enemy1green.tscn")
 var enemy2green = preload("res://scenes/enemies/enemy2green.tscn")
-var enemy2red = preload("res://scenes/enemies/enemy2red.tscn")
 
-var enemy_2_probability = 30
-var enemy_3_probability = 10
+var level_1_limit = 5
+var level_2_limit = 10
+var level_3_limit = 15
 
-var level_1_limit = 5#20
-var level_2_limit = 10#40
-var level_3_limit = 15#65
-var current_sublevel = 0
 var is_fighting_boss : bool = false
 var is_screen_shaken : bool = false
 
 func _ready():
-	clean_scene()	
-	SignalManager.final_blitz_warning.connect(on_final_blitz_warning)
-	update_ui()
-			
-			
+    enemy_scenes = [enemy2red, enemy1green, enemy2green]
+    sublevel_limits = [level_1_limit, level_2_limit, level_3_limit]
+    sublevel_configs = [
+        {"probabilities": [70, 20, 10]},
+        {"timer_min": 1.5, "timer_max": 3.0, "probabilities": [40, 30, 30]},
+        {"timer_min": 1.0, "timer_max": 2.0, "probabilities": [30, 30, 40]}
+    ]
+    update_ui()
+    super._ready()
+
 func update_ui():
-	SignalManager.speed_update.emit(false)
-	SignalManager.score_updated.emit(0)
-	SignalManager.weapon_speed_update.emit(false)
-	SignalManager.weapon_update.emit(false)
-	SignalManager.combo_update.emit()
+    SignalManager.speed_update.emit(false)
+    SignalManager.score_updated.emit(0)
+    SignalManager.weapon_speed_update.emit(false)
+    SignalManager.weapon_update.emit(false)
+    SignalManager.combo_update.emit()
 
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
-	verify_progress()
-		
-	if is_screen_shaken:
-		shake(3)
-		
-		
+    super._process(delta)
+    if is_screen_shaken:
+        shake(3)
+
 func verify_progress():
-	if level_3_limit <= GameManager.enemy_killed and current_sublevel == 3:
-		if is_fighting_boss:
-			move_boss()
-		else:
-			GameManager.is_final_blitz = true
-			SignalManager.boss_fight_start.emit()
-			is_screen_shaken = true
-			$ScreenShakeTimer.start()
-			$red_boss.is_hidden = false
-			is_fighting_boss = true
-			move_boss()			
-	if level_3_limit <= GameManager.enemy_killed and current_sublevel == 2:
-		enemy_spawn_timer.stop()
-		current_sublevel = 3				
-	if level_2_limit <= GameManager.enemy_killed and current_sublevel == 1:
-		GameManager.enemy_spawn_timer_min = 1.0
-		GameManager.enemy_spawn_timer_max = 2.0
-		current_sublevel = 2
-		enemy_2_probability = 70
-		enemy_3_probability = 40		
-	if level_1_limit <= GameManager.enemy_killed and current_sublevel == 0:
-		GameManager.enemy_spawn_timer_min = 1.5
-		GameManager.enemy_spawn_timer_max = 3.0
-		current_sublevel = 1
-		enemy_2_probability = 60
-		enemy_3_probability = 30
-		
-
-func _on_enemy_spawn_timer_timeout():
-	if !GameManager.is_final_blitz:
-		spawn_enemy()
-	
-	
-func spawn_enemy():	
-	var e
-	var rnd = randi_range(0,100)
-	if enemy_3_probability >=rnd:
-		e = enemy2green.instantiate() as Node2D
-	elif enemy_2_probability >=rnd:
-		e = enemy1green.instantiate() as Node2D
-	else:
-		e = enemy2red.instantiate() as Node2D
-	
-	get_tree().root.add_child(e)
-	var i = randi_range(1, 8)
-	match i:
-		1: 
-			e.global_position = enemy_spawner_1.global_position
-		2: 
-			e.global_position = enemy_spawner_2.global_position
-		3: 
-			e.global_position = enemy_spawner_3.global_position
-		4: 
-			e.global_position = enemy_spawner_4.global_position
-		5: 
-			e.global_position = enemy_spawner_5.global_position
-		6: 
-			e.global_position = enemy_spawner_6.global_position
-		7: 
-			e.global_position = enemy_spawner_7.global_position
-		8: 
-			e.global_position = enemy_spawner_8.global_position
-			
-	enemy_spawn_timer.wait_time = randf_range(GameManager.enemy_spawn_timer_min, GameManager.enemy_spawn_timer_max)
-	
-
-func clean_scene():
-	EnemyManager.speed = EnemyManager.MIN_SPEED
-	var enemies = get_tree().root.get_children()
-	for e in enemies:
-		if e.is_in_group("enemy"):
-			e.queue_free()
-			
-			
-func on_final_blitz_warning():
-	var enemies_missed = $HBEnemies.get_children()
-	if enemies_missed.is_empty():
-		SignalManager.start_final_blitz.emit()
-	else:
-		for enemy in enemies_missed:
-			enemy.play("flash")
-		$FinalBlitzWarningTimer.start()
-		
-
-func _on_final_blitz_warning_timer_timeout():
-        var enemies_missed = $HBEnemies.get_children()
-        for enemy in enemies_missed:
-                enemy.queue_free()
-        SignalManager.start_final_blitz.emit()
-
+    if level_3_limit <= GameManager.enemy_killed and current_sublevel == 3:
+        if is_fighting_boss:
+            move_boss()
+        else:
+            GameManager.is_final_blitz = true
+            SignalManager.boss_fight_start.emit()
+            is_screen_shaken = true
+            $ScreenShakeTimer.start()
+            $red_boss.is_hidden = false
+            is_fighting_boss = true
+            move_boss()
+    else:
+        super.verify_progress()
 
 func move_boss():
-	$red_boss.move()
-	
-	
-func shake(shake_amount : float):
-        $Camera2D.add_shake(shake_amount)
+    $red_boss.move()
 
+func shake(amount: float):
+    $Camera2D.add_shake(amount)
 
 func _on_screen_shake_timer_timeout():
-	is_screen_shaken = false
+    is_screen_shaken = false
+


### PR DESCRIPTION
## Summary
- add `BaseLevel` script to encapsulate enemy spawning and sublevel logic
- simplify `level1.gd`, `level2.gd` and `level3.gd` by inheriting from the new base
- move per-level configuration (spawn weights and timers) into the derived scripts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841d1a3db788322ac30b5316caae158